### PR TITLE
Remove the unneeded empty dictionary in NSPrivacyCollectedDataTypes

### DIFF
--- a/ios/Resources/PrivacyInfo.xcprivacy
+++ b/ios/Resources/PrivacyInfo.xcprivacy
@@ -14,9 +14,7 @@
 		</dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict/>
-	</array>
+	<array/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
Closes https://github.com/patrick-fu/flutter_shared_preference_app_group/issues/10